### PR TITLE
refactor: do not deploy if not needed

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,1 @@
+--container-architecture=linux/amd64

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,21 +3,71 @@ on:
     branches: [main]
 
 jobs:
+  prepare:
+    name: Prepare Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{steps.matrix.outputs.matrix}}
+      continue: ${{steps.matrix.outputs.continue}}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - run: echo "SITES=$(jq -c . < sites.json)" >> $GITHUB_ENV
+
+      - name: Packages Changed
+        id: changes
+
+        with:
+          list-files: shell
+          filters: |
+            deps:
+              - 'package.json'
+            sites:
+              - 'sites/!(template/**)/**'
+            packages:
+              - 'packages/**'
+        uses: dorny/paths-filter@v3
+
+      - name: Debug paths-filter
+        run: |
+          echo "sites files changed: ${{ steps.changes.outputs.sites_files }}"
+
+      - name: Transform Sites Changed
+        id: transformed-changes
+        run: |
+          sites=()
+
+          for filepath in ${{ steps.changes.outputs.sites_files }}; do
+              dir=$(echo "$filepath" | cut -d'/' -f2)
+              sites+=("$dir")
+          done
+
+          unique_sites=($(printf "%s\n" "${sites[@]}" | sort -u))
+          echo "SITES_CHANGED=${unique_sites[@]}" >> $GITHUB_ENV
+
+      - name: Build Dynamic Matrix
+        if: ${{ steps.changes.outputs.sites }}
+        id: matrix
+        run: |
+          if [[ ${{ steps.changes.outputs.packages }} == true ]] || [[ ${{ steps.changes.outputs.deps }} == true ]]; then
+            node ./scripts/build_matrix.mjs --all
+            echo "continue=true" >> $GITHUB_OUTPUT
+          elif [[ ${{ steps.changes.outputs.sites }} == true ]]; then
+            node ./scripts/build_matrix.mjs
+            echo "continue=true" >> $GITHUB_OUTPUT
+          else
+            # successful step, but do not continue with a deployment
+            echo "continue=false" >> $GITHUB_OUTPUT
+          fi
+
   publish:
+    needs: prepare
     name: Publish to Cloudflare Pages
+    if: ${{ needs.prepare.outputs.continue == 'true' }}
     runs-on: ubuntu-latest
     strategy:
-      matrix:
-        include:
-          # "project" here corresponds to the name of your project within Cloudflare
-          # "package" here refers to the name of the site as it is in the monorepo. "project" and "package" may not always be the same
-          - project: unicorn-demo
-            package: unicorn-demo
-          # Deploy multiple sites by adding more matrix entries following this syntax:
-          # - project: another-project
-          #   package: another-package
-          # - project: third-project
-          #   package: third-package
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
 
     permissions:
       contents: read

--- a/README.md
+++ b/README.md
@@ -55,10 +55,16 @@ Taking all this in mind, it will make sense to customize the template project wi
 
 If needed, consult the CLI help docs with:
 
-After you've run the script, be sure to follow the instructions at the end of the CLI. Notably, ensure adding your project to Cloudflare Pages and adding the deployment job to the GitHubAction workflow at `.github/workflows/publish.yml`.
-
 ```bash
 npm run new -- --help
+```
+
+After you've run the script, be sure to follow the instructions at the end of the CLI. Notably, ensure adding your project to Cloudflare Pages and adding the site configuration entry in `sites.json`. For these entries, the key should be the name of the package in the repo (the directory name of the site). The value should be the name of the project within Cloudflare Pages. For example, given a site living at `sites/my-site` and a corresponding Cloudflare Pages project given the name `my-cf-site`, the corresponding entry should be:
+
+```json
+{
+  "my-site": "my-cf-site"
+}
 ```
 
 ## Deployment

--- a/scripts/build_matrix.mjs
+++ b/scripts/build_matrix.mjs
@@ -1,0 +1,53 @@
+/**
+ * This script is used to build out the matrix that is the input
+ * to the publish job.
+ * */
+import { appendFileSync } from "node:fs";
+import { argv, env, exit } from "node:process";
+import * as os from "node:os";
+
+const { SITES, SITES_CHANGED } = env;
+
+try {
+  const [_node, _script, ...userArgs] = argv;
+  const doBuildAll = userArgs.some((arg) => arg === "--all");
+  if (!SITES) {
+    throw new Error("Needs SITES set. Are you missing the sites.json file?");
+  }
+
+  const allSites = JSON.parse(SITES);
+  if (doBuildAll) {
+    deploy(allSites);
+    exit(0);
+  } else {
+    if (!SITES_CHANGED || SITES_CHANGED === "") {
+      throw new Error("SITES_CHANGED is not set");
+    }
+
+    deploy(reduceSites(allSites, SITES_CHANGED));
+    exit(0);
+  }
+} catch (error) {
+  console.error("Error building sites", error);
+  exit(1);
+}
+
+function deploy(sites) {
+  let matrix = { include: [] };
+  for (const [key, value] of Object.entries(sites)) {
+    matrix.include.push({ package: key, project: value });
+  }
+  appendFileSync(
+    process.env.GITHUB_OUTPUT,
+    `matrix=${JSON.stringify(matrix)}${os.EOL}`
+  );
+}
+
+function reduceSites(allSites, sitesChanged) {
+  return Object.entries(allSites).reduce((accum, [pkg, project]) => {
+    if (sitesChanged.includes(pkg)) {
+      accum[pkg] = project;
+    }
+    return accum;
+  }, {});
+}

--- a/scripts/new_site.mjs
+++ b/scripts/new_site.mjs
@@ -82,7 +82,7 @@ program
       You're not done yet!
       1. Make sure your DNS is setup correctly if you are deploying to a custom domain.
       2. Make sure your Cloudflare Pages project is setup.
-      3. Make sure to add an entry to .github/workflows/publish.yml so that the project gets deployed.
+      3. Make sure to add an entry to sites.json
       4. Consider customizing your resume for this application specifically.
       `);
       Logger.info("========================================");

--- a/sites.json
+++ b/sites.json
@@ -1,0 +1,3 @@
+{
+  "unicorn-demo": "unicorn-demo"
+}

--- a/sites/template/src/theme.config.ts
+++ b/sites/template/src/theme.config.ts
@@ -2,7 +2,7 @@ export const THEME_CONFIG: App.Locals["config"] = {
   title: "Company x Me",
   company: "Company",
   yoe: 9,
-  name: "Testing",
+  name: "Me",
   desc: "Me's application for Company",
   website: "https://example.com",
   themeStyle: "light",

--- a/sites/template/src/theme.config.ts
+++ b/sites/template/src/theme.config.ts
@@ -2,7 +2,7 @@ export const THEME_CONFIG: App.Locals["config"] = {
   title: "Company x Me",
   company: "Company",
   yoe: 9,
-  name: "Me",
+  name: "Testing",
   desc: "Me's application for Company",
   website: "https://example.com",
   themeStyle: "light",


### PR DESCRIPTION
save time and money running ci machines by
refactoring the publish workflow to dynamically
build the sites to deploy based on git changes